### PR TITLE
Add previous voice toggle functionality

### DIFF
--- a/addon/globalPlugins/voiceToggle/__init__.py
+++ b/addon/globalPlugins/voiceToggle/__init__.py
@@ -31,12 +31,31 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(OptionsPanel)
 
 	@scriptHandler.script(
-		gesture="kb:NVDA+Alt+V",
 		# Translators: Gesture description for the Input gestures settings dialog
-		description=_("Toggles to the next voice."),
+		description=_("Switches to the next voice."),
+		category = _("Voice Toggle"),
 	)
 	def script_toggleVoice(self, gesture):
 		if not self.isSynthDoneSpeakingRegistered:
 			synthDoneSpeaking.register(self.app.handleDoneSpeaking)
 			self.isSynthDoneSpeakingRegistered = True
-		self.app.toggleVoice()
+		if len(self.app.voiceSettings) == 0:
+			return
+		nextIndex = self.app.getNextVoiceSettingsIndex(self.app.currentVoiceSettingsIndex)
+		newIndex = self.app.changeVoice(nextIndex)
+		self.app.currentVoiceSettingsIndex = newIndex
+
+	@scriptHandler.script(
+		# Translators: Gesture description for the Input gestures settings dialog
+		description=_("Switches to the previous voice."),
+		category = _("Voice Toggle"),
+	)
+	def script_previousVoice(self, gesture):
+		if not self.isSynthDoneSpeakingRegistered:
+			synthDoneSpeaking.register(self.app.handleDoneSpeaking)
+		self.isSynthDoneSpeakingRegistered = True
+		if len(self.app.voiceSettings) == 0:
+			return
+		previousIndex = self.app.getPreviousVoiceSettingsIndex(self.app.currentVoiceSettingsIndex)
+		newIndex = self.app.changeVoice(previousIndex)
+		self.app.currentVoiceSettingsIndex = newIndex

--- a/addon/globalPlugins/voiceToggle/voiceToggle.py
+++ b/addon/globalPlugins/voiceToggle/voiceToggle.py
@@ -260,6 +260,17 @@ class VoiceToggle:
 		newIndex = (index + 1) % voiceSettingsLength
 		return newIndex
 
+	def getPreviousVoiceSettingsIndex(self, index):
+		voiceSettingsLength = len(self.voiceSettings)
+		if voiceSettingsLength == 0:
+			return -1
+		
+		# If index is out of list bounds and list is not empty, return zero
+		if index < 0 or index >= voiceSettingsLength:
+			return 0
+		newIndex = (index - 1) % voiceSettingsLength
+		return newIndex
+
 	def changeVoice(self, newIndex, announceChange=True):
 		voiceSettingsLength = len(self.voiceSettings)
 		if (newIndex >= voiceSettingsLength) or (newIndex < 0):


### PR DESCRIPTION
Introduces a script and supporting method to switch to the previous voice in the voice settings. Updates gesture descriptions and ensures proper index handling for both next and previous voice toggling. The voice toggle has also been added in the NVDA's input gestures dialog